### PR TITLE
wrong bevel size when cell size lower than 10

### DIFF
--- a/src/grids/HexGrid.js
+++ b/src/grids/HexGrid.js
@@ -214,8 +214,8 @@ vg.HexGrid.prototype = {
 				bevelEnabled: true,
 				bevelSegments: 1,
 				steps: 1,
-				bevelSize: 0.5,
-				bevelThickness: 0.5
+				bevelSize: this.cellSize/20,
+				bevelThickness: this.cellSize/20
 			}
 		}
 		settings = vg.Tools.merge(settings, config);

--- a/src/grids/HexGrid.js
+++ b/src/grids/HexGrid.js
@@ -176,7 +176,7 @@ vg.HexGrid.prototype = {
 
 		var geo = this._geoCache[height];
 		if (!geo) {
-			this.extrudeSettings.amount = height;
+			this.extrudeSettings.depth = height;
 			geo = new THREE.ExtrudeGeometry(this.cellShape, this.extrudeSettings);
 			this._geoCache[height] = geo;
 		}
@@ -210,7 +210,7 @@ vg.HexGrid.prototype = {
 			cellSize: this.cellSize,
 			material: null,
 			extrudeSettings: {
-				amount: 1,
+				depth: 1,
 				bevelEnabled: true,
 				bevelSegments: 1,
 				steps: 1,

--- a/src/grids/SqrGrid.js
+++ b/src/grids/SqrGrid.js
@@ -204,8 +204,8 @@ vg.SqrGrid.prototype = {
 				bevelEnabled: true,
 				bevelSegments: 1,
 				steps: 1,
-				bevelSize: 0.5,
-				bevelThickness: 0.5
+				bevelSize: this.cellSize/20,
+				bevelThickness: this.cellSize/20
 			}
 		}
 		settings = vg.Tools.merge(settings, config);

--- a/src/grids/SqrGrid.js
+++ b/src/grids/SqrGrid.js
@@ -166,7 +166,7 @@ vg.SqrGrid.prototype = {
 
 		var geo = this._geoCache[height];
 		if (!geo) {
-			this.extrudeSettings.amount = height;
+			this.extrudeSettings.depth = height;
 			geo = new THREE.ExtrudeGeometry(this.cellShape, this.extrudeSettings);
 			this._geoCache[height] = geo;
 		}
@@ -200,7 +200,7 @@ vg.SqrGrid.prototype = {
 			cellSize: this.cellSize,
 			material: null,
 			extrudeSettings: {
-				amount: 1,
+				depth: 1,
 				bevelEnabled: true,
 				bevelSegments: 1,
 				steps: 1,


### PR DESCRIPTION
Bugfixe bevel size. Make it dependend to the cell size. With this fix, we can change "extrude height" without "buggy bevel size" when the cell size is lesser than 10.